### PR TITLE
Changing the default boot mount point

### DIFF
--- a/src/conf/fstab
+++ b/src/conf/fstab
@@ -1,3 +1,3 @@
-proc            /proc   proc    defaults          0       0
-/dev/mmcblk0p1  /boot   vfat    defaults          0       2
-/dev/mmcblk0p2  /       ext4    defaults,noatime  0       1
+proc            /proc           proc    defaults          0       0
+/dev/mmcblk0p1  /boot/firmware  vfat    defaults          0       2
+/dev/mmcblk0p2  /               ext4    defaults,noatime  0       1


### PR DESCRIPTION
I faced some problems when flashing the customized image with the provided configuration from `src/conf` folder from this repo.

It occurs every time when I try to install packages or run `apt update` or `apt upgrade`.

My problem was the same as [this StackOverflow question](https://askubuntu.com/questions/1380366/errors-encountered-while-processing-linux-firmware-linux-image-raspi-linux-ras) but unfortunately the solution to it was not the same.

After reading bunch of SubReddits, GitHub issues and so on I came up to this issue RPi-Distro/raspberrypi-sys-mods#88 which describes that they have changed the default mount point from `/boot` to `/boot/firmware`. <br>I think is specifically for Raspberry Pi OS that is based on Debian Bookworm which is used in this project.

I had to check for myself to be sure that the problem really lies there so I flashed on a new SD card a purely fresh image of Raspberry Pi OS Lite ([latest 2024-07-04 release](https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2024-07-04/)), booted up my Raspberry Pi with it and this is what `lsblk` told me:
```bash
$ lsblk
NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
mmcblk0     179:0    0 29.1G  0 disk
├─mmcblk0p1 179:1    0  128M  0 part /boot/firmware
└─mmcblk0p2 179:2    0   29G  0 part /
```

So I came back to the SD card with the custom image I had problems with, just modified the line in `/etc/fstab` where it was written `/boot` to `/boot/firmware`, rebooted and as a result everything was working correctly. 🎉

So yeah I am making my contribution to this project because it really helped me develop part of [my thesis project ](https://github.com/Heaven-Waves/central-node)for graduation university and is really useful one (I also really like it) 😄